### PR TITLE
Added copyright override

### DIFF
--- a/aemeds/blocks/article-copyright/article-copyright.js
+++ b/aemeds/blocks/article-copyright/article-copyright.js
@@ -7,8 +7,14 @@ export default async function decorate(block) {
   const copyrightPromise = fetch(`${localeInfo.urlPrefix}/blogs/fragments/article-copyright.plain.html`);
 
   const publicationDate = getMetadata('publication-date');
+
   const d = new Date(publicationDate);
-  const year = d.toLocaleDateString('en', { year: 'numeric' });
+  let year = d.toLocaleDateString('en', { year: 'numeric' });
+
+  const copyrightOverride = getMetadata('copyright');
+  if (copyrightOverride) {
+    year = copyrightOverride;
+  }
 
   const copyrightFragment = await copyrightPromise;
   if (!copyrightFragment.ok) {


### PR DESCRIPTION
As an author of the blogs, I would like in rare instanes to show a different year for the copyright notice.

Currently, the copyright notice will use the year of the Publication Date metadata.

An optional new metadata row, that allows setting a different year then the one in the publication date.
The article-copyright block would check this metadata and use it if it is present, or fall back to the publication date when it is missing in most cases.


Test URLs:
- Before: https://main--aemeds--servicenow-martech.hlx.page/blogs/drafts/copyright-override?disableLaunch=true
- After: https://copyrigh--aemeds--servicenow-martech.hlx.page/blogs/drafts/copyright-override?disableLaunch=true