### PR TITLE
Fixed article dates

### DIFF
--- a/aemeds/blocks/blog-list/blog-list.js
+++ b/aemeds/blocks/blog-list/blog-list.js
@@ -4,11 +4,11 @@ import {
 import {
   BLOG_QUERY_INDEX,
   BLOG_FILTERS,
-  formatDate,
   getLocaleInfo,
   serviceNowDefaultOrigin,
   analyticsGlobalClickTrack,
   analyticsCanonicStr,
+  formatDate,
 } from '../../scripts/scripts.js';
 import {
   a, button, div, li, span, ul,

--- a/aemeds/scripts/scripts.js
+++ b/aemeds/scripts/scripts.js
@@ -232,7 +232,7 @@ function buildArticleHeader(main) {
     authorHref = `/author/${toClassName(author)}`;
   }
 
-  const publicationDate = formatDate(getMetadata('publication-date'));
+  const publicationDate = formatDate(`${getMetadata('publication-date')} UTC`);
   //
   main.prepend(div(buildBlock('article-header', [
     [main.querySelector('h1')],


### PR DESCRIPTION
Published date is defined as UTC and displayed in browser's locale timezone. In the blog list the published date was considered UTC but in the article the published date was considered local timezone hence the difference in timezones that are after GMT (such as US). 

Test URLs:

- Before: https://main--aemeds--servicenow-martech.hlx.page/blogs?disableLaunch=true
- After: https://dates--aemeds--servicenow-martech.hlx.page/blogs?disableLaunch=true