### PR TITLE
Display dates in UTC - unadjusted to timezone

### DIFF
--- a/aemeds/scripts/scripts.js
+++ b/aemeds/scripts/scripts.js
@@ -200,6 +200,7 @@ export function formatDate(date) {
   const d = new Date(date);
   const locale = getLocale();
   return d.toLocaleDateString(locale, {
+    timeZone: 'UTC',
     month: 'long',
     day: '2-digit',
     year: 'numeric',


### PR DESCRIPTION
Published date from Word source shall be displayed as is regardless of timezone of the user. 

Test URLs:

- Before: https://main--aemeds--servicenow-martech.hlx.page/blogs?disableLaunch=true
- After: https://published--aemeds--servicenow-martech.hlx.page/blogs?disableLaunch=true