### PR TITLE
fix: Remove topic tags from Cards

### DIFF
--- a/aemeds/blocks/cards/cards.js
+++ b/aemeds/blocks/cards/cards.js
@@ -1,4 +1,4 @@
-/* eslint-disable max-len */
+/* eslint-disable max-len, no-unused-vars */
 import { createOptimizedPicture, readBlockConfig, toClassName } from '../../scripts/aem.js';
 import { a, div, h5 } from '../../scripts/dom-helpers.js';
 import ffetch from '../../scripts/ffetch.js';

--- a/aemeds/blocks/cards/cards.js
+++ b/aemeds/blocks/cards/cards.js
@@ -111,6 +111,7 @@ export async function renderCard(post, renderTopic = true) {
             ? createOptimizedPicture(new URL(post.image, window.origin).toString(), post.header)
             : createOptimizedPicture(new URL(PLACEHOLDER_IMAGE, window.origin).toString(), post.header),
         ),
+        // keeping this in for now, in case we need it again
         // renderTopic && post.topic ? div({ class: 'topic-tag' }, div(await localizedTopic(post.topic))) : '',
       ),
       div({ class: 'card-text' },

--- a/aemeds/blocks/cards/cards.js
+++ b/aemeds/blocks/cards/cards.js
@@ -111,7 +111,7 @@ export async function renderCard(post, renderTopic = true) {
             ? createOptimizedPicture(new URL(post.image, window.origin).toString(), post.header)
             : createOptimizedPicture(new URL(PLACEHOLDER_IMAGE, window.origin).toString(), post.header),
         ),
-        renderTopic && post.topic ? div({ class: 'topic-tag' }, div(await localizedTopic(post.topic))) : '',
+        // renderTopic && post.topic ? div({ class: 'topic-tag' }, div(await localizedTopic(post.topic))) : '',
       ),
       div({ class: 'card-text' },
         a({ href: post.path },


### PR DESCRIPTION
Test URLs:
With Launch
- Before: https://main--aemeds--servicenow-martech.aem.live/blogs
- After: https://notag--aemeds--servicenow-martech.aem.live/blogs

With Launch Disabled
- Before: https://main--aemeds--servicenow-martech.aem.live/blogs?disableLaunch=true
- After: https://notag--aemeds--servicenow-martech.aem.live/blogs?disableLaunch=true
