### PR TITLE
fix: Remove EMEA Insights blogs from the Homepage

### DIFF
--- a/aemeds/blocks/cards/cards.js
+++ b/aemeds/blocks/cards/cards.js
@@ -15,6 +15,7 @@ import {
 
 const TRENDS_AND_RESEARCH = toClassName('Trends and Research');
 const RESEARCH_CATEGORY = toClassName('ServiceNow Research');
+const EMEA_INSIGHTS_CATEGORY = toClassName('EMEA Insights');
 const PLACEHOLDER_IMAGE = '/blogs/assets/servicenow-placeholder.png';
 
 async function waitForEagerImageLoad(img) {
@@ -159,7 +160,9 @@ function fetchAPIBasedCards(cardInfos, apis) {
 async function homepageLatestRule(blogs, cardInfos, idx) {
   cardInfos[idx] = await blogs
     .filter(BLOG_FILTERS.locale)
-    .filter((blog) => !BLOG_FILTERS.category(RESEARCH_CATEGORY, blog))
+    .filter(
+      (blog) => !BLOG_FILTERS.category(RESEARCH_CATEGORY, blog) && !BLOG_FILTERS.category(EMEA_INSIGHTS_CATEGORY, blog),
+    )
     .limit(3)
     .all();
 }


### PR DESCRIPTION
Test URLs:
With Launch
- Before: https://main--aemeds--servicenow-martech.aem.live/uk/blogs
- After: https://noemea--aemeds--servicenow-martech.aem.live/uk/blogs

With Launch Disabled
- Before: https://main--aemeds--servicenow-martech.aem.live/uk/blogs?disableLaunch=true
- After: https://noemea--aemeds--servicenow-martech.aem.live/uk/blogs?disableLaunch=true
