### PR TITLE
feat: Allow category, new trend, trend and topic to be lists

### DIFF
--- a/aemeds/blocks/blog-list/blog-list.js
+++ b/aemeds/blocks/blog-list/blog-list.js
@@ -157,8 +157,8 @@ export default async function decorate(block) {
 
   if (['category', 'topic', 'newTrend', 'trend'].includes(filterKey)) {
     filterValue = filterValue.split(',')
-      .map(s => s.trim())
-      .map(v => toClassName(v));
+      .map((s) => s.trim())
+      .map((v) => toClassName(v));
   } else if (filterKey === 'author') {
     // eslint-disable-next-line prefer-destructuring
     filterValue = new URL(filterValue, serviceNowDefaultOrigin).pathname.split('.')[0];

--- a/aemeds/blocks/blog-list/blog-list.js
+++ b/aemeds/blocks/blog-list/blog-list.js
@@ -156,7 +156,9 @@ export default async function decorate(block) {
   filterValue = filterValue.textContent.trim();
 
   if (['category', 'topic', 'newTrend', 'trend'].includes(filterKey)) {
-    filterValue = toClassName(filterValue);
+    filterValue = filterValue.split(',')
+      .map(s => s.trim())
+      .map(v => toClassName(v));
   } else if (filterKey === 'author') {
     // eslint-disable-next-line prefer-destructuring
     filterValue = new URL(filterValue, serviceNowDefaultOrigin).pathname.split('.')[0];

--- a/aemeds/blocks/cards/cards.js
+++ b/aemeds/blocks/cards/cards.js
@@ -161,7 +161,7 @@ async function homepageLatestRule(blogs, cardInfos, idx) {
   cardInfos[idx] = await blogs
     .filter(BLOG_FILTERS.locale)
     .filter(
-      (blog) => !BLOG_FILTERS.category(RESEARCH_CATEGORY, blog) && !BLOG_FILTERS.category(EMEA_INSIGHTS_CATEGORY, blog),
+      (blog) => !BLOG_FILTERS.category([RESEARCH_CATEGORY], blog) && !BLOG_FILTERS.category([EMEA_INSIGHTS_CATEGORY], blog),
     )
     .limit(3)
     .all();
@@ -173,7 +173,7 @@ async function homepageCategoryRule(blogs, cardInfos, idx, config) {
 
   cardInfos[idx] = await blogs
     .filter(BLOG_FILTERS.locale)
-    .filter((blog) => BLOG_FILTERS.category(toClassName(config.category), blog)
+    .filter((blog) => BLOG_FILTERS.category([toClassName(config.category)], blog)
       && !latestLinks.includes(blog.path))
     .limit(3)
     .all();
@@ -182,7 +182,7 @@ async function homepageCategoryRule(blogs, cardInfos, idx, config) {
 async function sidebarFeaturedRule(blogs, cardInfos, idx) {
   cardInfos[idx] = await blogs
     .filter(BLOG_FILTERS.locale)
-    .filter((blog) => !BLOG_FILTERS.trend(TRENDS_AND_RESEARCH, blog))
+    .filter((blog) => !BLOG_FILTERS.trend([TRENDS_AND_RESEARCH], blog))
     .filter((blog) => blog.path !== window.location.pathname)
     .limit(3)
     .all();
@@ -190,7 +190,7 @@ async function sidebarFeaturedRule(blogs, cardInfos, idx) {
 
 async function sidebarTrendsAndResearchRule(blogs, cardInfos, idx) {
   cardInfos[idx] = await blogs.filter(BLOG_FILTERS.locale)
-    .filter((blog) => BLOG_FILTERS.trend(TRENDS_AND_RESEARCH, blog))
+    .filter((blog) => BLOG_FILTERS.trend([TRENDS_AND_RESEARCH], blog))
     .filter((blog) => blog.path !== window.location.pathname)
     .limit(3)
     .all();

--- a/aemeds/scripts/scripts.js
+++ b/aemeds/scripts/scripts.js
@@ -161,10 +161,10 @@ export function getLocale() {
 
 export const BLOG_FILTERS = {
   locale: (blog) => getLocale() === blog.locale,
-  trend: (trend, blog) => trend === toClassName(blog.trend),
-  newTrend: (newTrend, blog) => newTrend === toClassName(blog.newTrend),
-  category: (category, blog) => category === toClassName(blog.category),
-  topic: (topic, blog) => topic === toClassName(blog.topic),
+  trend: (trends, blog) => trends.includes(toClassName(blog.trend)),
+  newTrend: (newTrends, blog) => newTrends.includes(toClassName(blog.newTrend)),
+  category: (categories, blog) => categories.includes(toClassName(blog.category)),
+  topic: (topics, blog) => topics.includes(toClassName(blog.topic)),
   year: (year, blog) => year === blog.year,
   author: (authorUrl, blog) => (
     authorUrl === new URL(blog.authorUrl, serviceNowDefaultOrigin).pathname.split('.')[0]


### PR DESCRIPTION
ServiceNow requests to rename a trend.
In order to not have to change all the previous word documents, this PR makes the filter pages accept comma separated values as for the blog list

Test URLs:
With Launch
- Before: https://main--aemeds--servicenow-martech.aem.live/blogs
- After: https://newtrendlist--aemeds--servicenow-martech.aem.live/blogs

With Launch Disabled
- Before: https://main--aemeds--servicenow-martech.aem.live/blogs?disableLaunch=true
- After: https://newtrendlist--aemeds--servicenow-martech.aem.live/blogs?disableLaunch=true
