### PR TITLE
fix: Don't wait for lazy images which are not in view

### DIFF
--- a/aemeds/blocks/header/header.js
+++ b/aemeds/blocks/header/header.js
@@ -54,7 +54,7 @@ export async function waitImagesLoad(block) {
       continue;
     }
 
-    new Promise((resolve) => {
+    await new Promise((resolve) => {
       if (img && !img.complete) {
         img.addEventListener('load', resolve);
         img.addEventListener('error', resolve);

--- a/aemeds/blocks/header/header.js
+++ b/aemeds/blocks/header/header.js
@@ -24,11 +24,31 @@ export function fixRelativeDAMImages(block, dataDomain) {
     .forEach((image) => { image.src = new URL(new URL(image.src).pathname, dataDomain); });
 }
 
+async function isImageInView(img) {
+  return await new Promise((resolve) => {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          observer.disconnect();
+          resolve(true);
+        }
+      });
+      observer.disconnect();
+      resolve(false);
+    });
+    observer.observe(img);
+  })
+}
+
 export async function waitImagesLoad(block) {
   const images = block.querySelectorAll('img');
 
   for (let i = 0; i < images.length; i += 1) {
     const img = images[i];
+
+    if (img.loading === 'lazy' && !await isImageInView(img)) {
+      continue;
+    }
 
     // eslint-disable-next-line no-await-in-loop
     await new Promise((resolve) => {

--- a/aemeds/blocks/header/header.js
+++ b/aemeds/blocks/header/header.js
@@ -46,10 +46,12 @@ export async function waitImagesLoad(block) {
   for (let i = 0; i < images.length; i += 1) {
     const img = images[i];
 
+    if (!img) continue;
+
     if (img.loading === 'lazy' && !await isImageInView(img)) {
+      // this image will not be loaded by the browser yet
       continue;
     }
-
     // eslint-disable-next-line no-await-in-loop
     await new Promise((resolve) => {
       if (img && !img.complete) {

--- a/aemeds/blocks/header/header.js
+++ b/aemeds/blocks/header/header.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-await-in-loop, no-continue */
 import { loadCSS, loadScript } from '../../scripts/aem.js';
 import { section } from '../../scripts/dom-helpers.js';
 import { getLocale } from '../../scripts/scripts.js';
@@ -25,9 +26,9 @@ export function fixRelativeDAMImages(block, dataDomain) {
 }
 
 async function isImageInView(img) {
-  return await new Promise((resolve) => {
+  return new Promise((resolve) => {
     const observer = new IntersectionObserver((entries) => {
-      entries.forEach(entry => {
+      entries.forEach((entry) => {
         if (entry.isIntersecting) {
           observer.disconnect();
           resolve(true);
@@ -37,7 +38,7 @@ async function isImageInView(img) {
       resolve(false);
     });
     observer.observe(img);
-  })
+  });
 }
 
 export async function waitImagesLoad(block) {
@@ -52,8 +53,8 @@ export async function waitImagesLoad(block) {
       // this image will not be loaded by the browser yet
       continue;
     }
-    // eslint-disable-next-line no-await-in-loop
-    await new Promise((resolve) => {
+
+    new Promise((resolve) => {
       if (img && !img.complete) {
         img.addEventListener('load', resolve);
         img.addEventListener('error', resolve);


### PR DESCRIPTION
The new version of NaaS has introduced images that are lazy loaded. Waiting for this images will never finish, so we need to detect them and skip them, otherwise the footer and other lazy resources will never load.

Test URLs:
With Launch
- Before: https://main--aemeds--servicenow-martech.aem.live/blogs
- After: https://fixheader2--aemeds--servicenow-martech.aem.live/blogs

With Launch Disabled
- Before: https://main--aemeds--servicenow-martech.aem.live/blogs?disableLaunch=true
- After: https://fixheader2--aemeds--servicenow-martech.aem.live/blogs?disableLaunch=true
