### PR TITLE
fix: Static Cards should not depend on "topic" metadata

### DIFF
--- a/aemeds/blocks/cards/cards.js
+++ b/aemeds/blocks/cards/cards.js
@@ -138,14 +138,14 @@ function fetchLinkBasedCards(cardInfos, links) {
       const header = fragmentElement.querySelector('h1').textContent;
       const image = fragmentElement.querySelector('img')
         .getAttribute('src');
-      const topic = fragmentElement.querySelector('meta[name="topic"]')
-        .getAttribute('content');
+      // const topic = fragmentElement.querySelector('meta[name="topic"]')
+      //   .getAttribute('content');
 
       cardInfos[postLink.idx] = {
         path: postLink.href,
         header,
         image,
-        topic,
+        // topic,
       };
     }
   });


### PR DESCRIPTION
Test URLs:
With Launch
- Before: https://main--aemeds--servicenow-martech.aem.live/blogs
- After: https://fix-card-static--aemeds--servicenow-martech.aem.page/blogs

With Launch Disabled
- Before: https://main--aemeds--servicenow-martech.aem.live/blogs?disableLaunch=true
- After: https://fix-card-static--aemeds--servicenow-martech.aem.page/blogs?disableLaunch=true
